### PR TITLE
Allow link redirect.

### DIFF
--- a/magzdb/magzdb.py
+++ b/magzdb/magzdb.py
@@ -56,7 +56,7 @@ class Magzdb:
 
     def _html_regex(self, url, regex):
         try:
-            docstring = self.request.get(url, allow_redirects=False).text
+            docstring = self.request.get(url, allow_redirects=True).text
             return [a for a in re.findall(regex, docstring) if a]
         except re.error as e:
             logger.error(e)


### PR DESCRIPTION
Magzdb now redirects it's previous direct downloads to http://elibrary.keenetic.pro/
Turning allow_redirects flag from False to True solves the problem and downloads the file instead of continuing over it.